### PR TITLE
Update __main__.py to store auto_adjust_urgency argument

### DIFF
--- a/taskcheck/__main__.py
+++ b/taskcheck/__main__.py
@@ -49,8 +49,10 @@ arg_parser.add_argument(
 )
 arg_parser.add_argument(
     "--no-auto-adjust-urgency",
-    action="store_true",
-    help="disable automatically reduction of urgency weight when tasks cannot be completed on time",
+    dest="auto_adjust_urgency",    # ← the name you want in args
+    action="store_false",          # ← if the flag is present, set it to False
+    default=True,                  # ← if the flag is absent, leave it at True
+    help="disable automatic reduction of urgency weight … (default: enabled)",
 )
 
 


### PR DESCRIPTION
If ```--no-auto-adjust-urgency``` flag is passed, set the argument ```auto_adjust_urgency``` to ```True``` instead of creating an argument called ```no_auto_adjust_urgency``` which isn't otherwise used.

Separate pull request to follow that will modify the ```test_main.py``` test case to accommodate.  ```parallel.py``` already looks for ```auto_adjust_urgency```.