### PR TITLE
Updated get_tasks in report.py to include the "urgency" key

### DIFF
--- a/taskcheck/report.py
+++ b/taskcheck/report.py
@@ -194,6 +194,7 @@ def get_tasks(config, tasks, year, month, day):
                         "id": task["id"],
                         "project": task.get("project", ""),
                         "description": task["description"],
+                        "urgency": task["urgency"],
                         "scheduling_day": f"{year}-{month}-{day}",
                         "scheduling_hours": m.group(1),
                         **{


### PR DESCRIPTION
Now appending the "urgency" in valid_tasks.  We can't sort on a missing key.  Corrects the following error when running `taskcheck -r eow`, for example:

```
Traceback (most recent call last):                       
  File "/home/scott/.local/bin/taskcheck", line 8, in <module>                                                                                                                                                                      
    sys.exit(main())
             ~~~~^^                                                                                                
  File "/home/scott/.local/share/pipx/venvs/taskcheck/lib/python3.13/site-packages/taskcheck/__main__.py", line 131, in main
    generate_report(                                                                                               
    ~~~~~~~~~~~~~~~^                                                                                               
        config,                                                                                                    
        ^^^^^^^                                                                                                    
    ...<4 lines>...                                                                                                
        scheduling_results=scheduling_results,   
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )              
    ^                                                    
  File "/home/scott/.local/share/pipx/venvs/taskcheck/lib/python3.13/site-packages/taskcheck/report.py", line 287, in generate_report
    this_day_tasks = get_tasks(config, tasks, year, month, day)
  File "/home/scott/.local/share/pipx/venvs/taskcheck/lib/python3.13/site-packages/taskcheck/report.py", line 205, in get_tasks
    valid_tasks = sorted(valid_tasks, key=lambda x: x["urgency"], reverse=True)
  File "/home/scott/.local/share/pipx/venvs/taskcheck/lib/python3.13/site-packages/taskcheck/report.py", line 205, in <lambda>
    valid_tasks = sorted(valid_tasks, key=lambda x: x["urgency"], reverse=True)
                                                    ~^^^^^^^^^^^
KeyError: 'urgency'                                                                                                
➜
```