### PR TITLE
prevent --install from triggering hidden confirmation dialogs of TaskWarrior

### DIFF
--- a/taskcheck/install.py
+++ b/taskcheck/install.py
@@ -24,7 +24,16 @@ emoji_keywords = {}
 
 
 def apply_config(key, value):
-    subprocess.run(["task", "config", key, value], stdout=subprocess.DEVNULL)
+    subprocess.run(
+        [
+            "task",
+            "rc.confirmation=0",
+            "config",
+            key,
+            value,
+        ],
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def install():


### PR DESCRIPTION
fixes #7 

However, this change introduces the artifact that `taskcheck --install` triggers a lot of log messages stating that `Configuration override rc.confirmation=0` because TaskWarrior sends that to stderr. However, I would not like to just silence stderr in case of any real errors or important hints coming up. So I would propose to either accept this, or to selectively filter out these the messages in stderr (which would be a little bit of work).

I think you should decide what you would find more appropriate.